### PR TITLE
Incomplete rewind. Score won't reset correctly

### DIFF
--- a/PracticePlugin/Plugin.cs
+++ b/PracticePlugin/Plugin.cs
@@ -193,6 +193,7 @@ namespace PracticePlugin
                 // Hack to ensure score is applied on rewind
                 // prevFrameScore is applied on LateUpdate and the score will sometimes not be applied when rewinding.
                 // This just applies the score again on the next frame to make sure that it changes.
+                // May not be required
                 if (applyScoreAgain)
                 {
                     RewindScore(currentBeat);
@@ -234,6 +235,7 @@ namespace PracticePlugin
         {
             ScoreListItem scoreListItem;
             
+            // Loop through and log the data for all scores saved in the scoresDict
             String message = "\n";
             foreach (int key in scoresDict.Keys)
             {
@@ -252,8 +254,9 @@ namespace PracticePlugin
 
             Log(message);
 
-            // Reset score to where it was at destination
+            // Get the score at the destination beat
             scoreListItem = scoresDict[destinationBeat];
+            
             Log("destinationBeat: " + destinationBeat
                 +  " scoreListItem baseScore:" + scoreListItem.baseScore
                 + " previousScore:" + scoreListItem.previousScore
@@ -265,9 +268,9 @@ namespace PracticePlugin
                 + " playerHeadWasInObstacle:" + scoreListItem.playerHeadWasInObstacle
                 + "\n");
 
-            // Get the score data at the new position
+            // Get the score data at the destination beat
             ReflectionUtil.SetPrivateField(scoreController, "_baseScore", scoreListItem.baseScore);
-            ReflectionUtil.SetPrivateField(scoreController, "_prevFrameScore", -1); // <-------------------------------- Trying to force scoreDidChangeEvent
+            ReflectionUtil.SetPrivateField(scoreController, "_prevFrameScore", scoreListItem.previousScore); // <-------- Trying to force scoreDidChangeEvent
             ReflectionUtil.SetPrivateField(scoreController, "_multiplier", scoreListItem.multiplier);
             ReflectionUtil.SetPrivateField(scoreController, "_multiplierIncreaseProgress", scoreListItem.multiplierIncreaseProgress);
             ReflectionUtil.SetPrivateField(scoreController, "_multiplierIncreaseMaxProgress", scoreListItem.multiplierIncreaseMaxProgress);
@@ -276,7 +279,7 @@ namespace PracticePlugin
             ReflectionUtil.SetPrivateField(scoreController, "_playerHeadWasInObstacle", scoreListItem.playerHeadWasInObstacle);
             ReflectionUtil.SetPrivateField(scoreController, "_afterCutScoreBuffers", scoreListItem.afterCutScoreBuffers);
 
-            // Trigger the scoreController's late update to
+            // Trigger the scoreController's late update to unsure a scoreDidChangeEvent
             scoreController.LateUpdate();
         }
         

--- a/PracticePlugin/Plugin.cs
+++ b/PracticePlugin/Plugin.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UnityEngine.XR;
+using System.Collections;
+using System.Collections.Generic;
 using Object = UnityEngine.Object;
 
 namespace PracticePlugin
@@ -55,15 +57,25 @@ namespace PracticePlugin
 		private static AudioSource _songAudio;
 		private static AudioSource _noteCutAudioSource;
 		private string _lastLevelId;
-		
-		public string Name
+
+        private GameSongController gameSongController;
+        private SongObjectSpawnController songObjectSpawnController;
+        private ScoreController scoreController;
+        private static int rewindAmountBeats = 4;
+        private static int tmpBeat = 0;
+        private static int sampleRate          = 44100;
+        private Dictionary<int, ScoreListItem> scoresDict;
+        private static int previousBeat = -1;
+        private static bool applyScoreAgain = false; // Hack to ensure score is applied on rewind
+
+        public string Name
 		{
 			get { return "Practice Plugin"; }
 		}
 
 		public string Version
 		{
-			get { return "v1.1"; }
+			get { return "v1.2"; }
 		}
 		
 		public void OnApplicationStart()
@@ -95,7 +107,7 @@ namespace PracticePlugin
 					SettingsObject.GetComponentInChildren<TMP_Text>().text = "SPEED";
 					Object.DontDestroyOnLoad(SettingsObject);
 				}
-			}
+            }
 			else
 			{
 				if (_mainGameSceneSetupData == null)
@@ -130,7 +142,13 @@ namespace PracticePlugin
 					.transform.parent;
 				canvas.gameObject.AddComponent<SpeedSettingsCreator>();
 				TimeScale = TimeScale;
-			}
+
+                gameSongController = Resources.FindObjectsOfTypeAll<GameSongController>().FirstOrDefault();
+                songObjectSpawnController = Resources.FindObjectsOfTypeAll<SongObjectSpawnController>().FirstOrDefault();
+                scoreController = Resources.FindObjectsOfTypeAll<ScoreController>().FirstOrDefault<ScoreController>();
+
+                scoresDict = new Dictionary<int, ScoreListItem>();
+            }
 		}
 
 		public void OnLevelWasLoaded(int level)
@@ -140,17 +158,205 @@ namespace PracticePlugin
 
 		public void OnLevelWasInitialized(int level)
 		{
-			
-		}
 
-		public void OnUpdate()
+        }
+
+        public void OnUpdate()
 		{
-			
+            if (Enabled)
+            {
+                // songTime is in seconds
+                int currentBeat = (int)((_audioTimeSync.songTime / 60f) * gameSongController.beatsPerMinute);
+
+                //Log("currentBeat:" + currentBeat + " songTime" + _audioTimeSync.songTime);
+                if (currentBeat > previousBeat)
+                {
+                    previousBeat = currentBeat;
+                    Log("currentBeat:" + currentBeat + " songTime:" + _audioTimeSync.songTime);
+                    
+                    ScoreListItem scoreListItem = new ScoreListItem
+                    {
+                        baseScore = ReflectionUtil.GetPrivateField<int>(scoreController, "_baseScore"),
+                        multiplier = ReflectionUtil.GetPrivateField<int>(scoreController, "_multiplier"),
+                        multiplierIncreaseProgress = ReflectionUtil.GetPrivateField<int>(scoreController, "_multiplierIncreaseProgress"),
+                        multiplierIncreaseMaxProgress = ReflectionUtil.GetPrivateField<int>(scoreController, "_multiplierIncreaseMaxProgress"),
+                        combo = ReflectionUtil.GetPrivateField<int>(scoreController, "_combo"),
+                        maxCombo = ReflectionUtil.GetPrivateField<int>(scoreController, "_maxCombo"),
+                        playerHeadWasInObstacle = ReflectionUtil.GetPrivateField<bool>(scoreController, "_playerHeadWasInObstacle"),
+                        afterCutScoreBuffers = ReflectionUtil.GetPrivateField<List<AfterCutScoreBuffer>>(scoreController, "_afterCutScoreBuffers")
+                    };
+
+                    // Add the data to the dictionary
+                    scoresDict[currentBeat] = scoreListItem;
+                }
+
+                // Hack to ensure score is applied on rewind
+                // prevFrameScore is applied on LateUpdate and the score will sometimes not be applied when rewinding.
+                // This just applies the score again on the next frame to make sure that it changes.
+                if (applyScoreAgain)
+                {
+                    RewindScore(currentBeat);
+                    applyScoreAgain = false;
+                }
+                else if (Input.GetKeyDown(KeyCode.R))
+                {
+                    // Trigger rewind here.
+                    tmpBeat = currentBeat - rewindAmountBeats;
+                    Rewind(tmpBeat < 0 ? 0 : tmpBeat);
+                    applyScoreAgain = true;
+                }
+            }
 		}
 
 		public void OnFixedUpdate()
 		{
 			
 		}
-	}
+
+        private void Rewind(int destinationBeat)
+        {
+            previousBeat = destinationBeat;
+
+            var destinationTime = destinationBeat * 60f / gameSongController.beatsPerMinute; // Convert beats to time in sec
+            Log("Rewinding to beat:" + destinationBeat + " at time:" + destinationTime);
+
+            DeleteExistingNotes();
+            
+            WalkBackIndexes(destinationTime);
+
+            _songAudio.timeSamples = (int)(destinationTime * sampleRate);                                  // Rewind the audio file
+            ReflectionUtil.SetPrivateField(_audioTimeSync, "_prevAudioSamplePos", _songAudio.timeSamples); // This must be set or song will end instantly
+
+            RewindScore(destinationBeat);
+        }
+
+        private void RewindScore(int destinationBeat)
+        {
+            ScoreListItem scoreListItem;
+            
+            String message = "\n";
+            foreach (int key in scoresDict.Keys)
+            {
+                scoreListItem = scoresDict[key];
+                message = message + "key: " + key 
+                    + " scoreListItem baseScore:" + scoreListItem.baseScore
+                    + " previousScore:" + scoreListItem.previousScore
+                    + " multiplier:" + scoreListItem.multiplier
+                    + " multiplierIncreaseProgress:" + scoreListItem.multiplierIncreaseProgress
+                    + " multiplierIncreaseMaxProgress:" + scoreListItem.multiplierIncreaseMaxProgress
+                    + " combo:" + scoreListItem.combo
+                    + " maxCombo:" + scoreListItem.maxCombo
+                    + " playerHeadWasInObstacle:" + scoreListItem.playerHeadWasInObstacle
+                    + "\n";
+            }
+
+            Log(message);
+
+            // Reset score to where it was at destination
+            scoreListItem = scoresDict[destinationBeat];
+            Log("destinationBeat: " + destinationBeat
+                +  " scoreListItem baseScore:" + scoreListItem.baseScore
+                + " previousScore:" + scoreListItem.previousScore
+                + " multiplier:" + scoreListItem.multiplier
+                + " multiplierIncreaseProgress:" + scoreListItem.multiplierIncreaseProgress
+                + " multiplierIncreaseMaxProgress:" + scoreListItem.multiplierIncreaseMaxProgress
+                + " combo:" + scoreListItem.combo
+                + " maxCombo:" + scoreListItem.maxCombo
+                + " playerHeadWasInObstacle:" + scoreListItem.playerHeadWasInObstacle
+                + "\n");
+
+            // Get the score data at the new position
+            ReflectionUtil.SetPrivateField(scoreController, "_baseScore", scoreListItem.baseScore);
+            ReflectionUtil.SetPrivateField(scoreController, "_prevFrameScore", -1); // <-------------------------------- Trying to force scoreDidChangeEvent
+            ReflectionUtil.SetPrivateField(scoreController, "_multiplier", scoreListItem.multiplier);
+            ReflectionUtil.SetPrivateField(scoreController, "_multiplierIncreaseProgress", scoreListItem.multiplierIncreaseProgress);
+            ReflectionUtil.SetPrivateField(scoreController, "_multiplierIncreaseMaxProgress", scoreListItem.multiplierIncreaseMaxProgress);
+            ReflectionUtil.SetPrivateField(scoreController, "_combo", scoreListItem.combo);
+            ReflectionUtil.SetPrivateField(scoreController, "_maxCombo", scoreListItem.maxCombo);
+            ReflectionUtil.SetPrivateField(scoreController, "_playerHeadWasInObstacle", scoreListItem.playerHeadWasInObstacle);
+            ReflectionUtil.SetPrivateField(scoreController, "_afterCutScoreBuffers", scoreListItem.afterCutScoreBuffers);
+
+            // Trigger the scoreController's late update to
+            scoreController.LateUpdate();
+        }
+        
+        // Change the indexes for the next objects to hit, to account for the rewind
+        private void WalkBackIndexes(float destinationTime)
+        {
+            // Move indexes back for all object arrays
+            var _songObjectCallbackData = ReflectionUtil.GetPrivateField<List<SongController.SongObjectCallbackData>>(gameSongController, "_songObjectCallbackData");
+            var _songData = ReflectionUtil.GetPrivateField<SongData>(gameSongController, "_songData");
+            var _nextEventIndex = ReflectionUtil.GetPrivateField<int>(gameSongController, "_nextEventIndex");
+
+            float songTime = _audioTimeSync.songTime;
+            for (int i = 0; i < _songObjectCallbackData.Count; i++)
+            {
+                SongController.SongObjectCallbackData songObjectCallbackData = _songObjectCallbackData[i];
+                for (int j = 0; j < gameSongController.noteLinesCount; j++)
+                {
+                    // Loop backwards from the current "nextObjectIndexInLine"
+                    // Break when we hit an object that is less than the current time, thus storing the next object that should be hit
+                    while (songObjectCallbackData.nextObjectIndexInLine[j] > 0)
+                    {
+                        SongObjectData songObjectData = _songData.SongLinesData[j].songObjectsData[songObjectCallbackData.nextObjectIndexInLine[j]];
+                        if (songObjectData.time < destinationTime)
+                        {
+                            break;
+                        }
+                        songObjectCallbackData.nextObjectIndexInLine[j]--;
+                    }
+                }
+            }
+
+            // Loop backwards from the current nextEventIndex.
+            // Break when we hit an index that is less than the current time, thus storing the next event that should be played
+            while (_nextEventIndex > 0)
+            {
+                SongEventData songEventData = _songData.SongEventData[_nextEventIndex];
+                if (songEventData.time < destinationTime)
+                {
+                    break;
+                }
+                _nextEventIndex--;
+            }
+
+        }
+
+        private void DeleteExistingNotes()
+        {
+            var _gameNotePrefab = ReflectionUtil.GetPrivateField<NoteController>(songObjectSpawnController, "_gameNotePrefab");
+            var _bombNotePrefab = ReflectionUtil.GetPrivateField<BombNoteController>(songObjectSpawnController, "_bombNotePrefab");
+            var _obstacleBottomPrefab = ReflectionUtil.GetPrivateField<ObstacleController>(songObjectSpawnController, "_obstacleBottomPrefab");
+            var _obstacleTopPrefab = ReflectionUtil.GetPrivateField<ObstacleController>(songObjectSpawnController, "_obstacleTopPrefab");
+
+            // Same duration used in game
+            float duration = 1.4f;
+            List<NoteController> cubeNoteControllers = _gameNotePrefab.GetSpawned<NoteController>();
+            foreach (NoteController noteController in cubeNoteControllers)
+            {
+                noteController.Dissolve(duration);
+            }
+            List<BombNoteController> bombNoteControllers = _bombNotePrefab.GetSpawned<BombNoteController>();
+            foreach (BombNoteController bombNoteController in bombNoteControllers)
+            {
+                bombNoteController.Dissolve(duration);
+            }
+            List<ObstacleController> obstacleBottomControllers = _obstacleBottomPrefab.GetSpawned<ObstacleController>();
+            foreach (ObstacleController obstacleController in obstacleBottomControllers)
+            {
+                obstacleController.Dissolve(duration);
+            }
+            List<ObstacleController> obstacleTopControllers = _obstacleTopPrefab.GetSpawned<ObstacleController>();
+            foreach (ObstacleController obstacleController2 in obstacleTopControllers)
+            {
+                obstacleController2.Dissolve(duration);
+            }
+        }
+        
+        public static void Log(string message)
+        {
+            Debug.Log("PracticePlugin: " + message);
+            Console.WriteLine("PracticePlugin: " + message);
+        }
+    }
 }

--- a/PracticePlugin/PracticePlugin.csproj
+++ b/PracticePlugin/PracticePlugin.csproj
@@ -33,50 +33,51 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="IllusionPlugin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IllusionPlugin.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IllusionPlugin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="TextMeshPro-1.0.55.2017.1.0b12, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\TextMeshPro-1.0.55.2017.1.0b12.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\TextMeshPro-1.0.55.2017.1.0b12.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.VRModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>D:\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
+      <HintPath>..\..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReflectionUtil.cs" />
+    <Compile Include="ScoreListItem.cs" />
     <Compile Include="SpeedSettingsController.cs" />
     <Compile Include="SpeedSettingsCreator.cs" />
   </ItemGroup>

--- a/PracticePlugin/ReflectionUtil.cs
+++ b/PracticePlugin/ReflectionUtil.cs
@@ -9,11 +9,12 @@ namespace PracticePlugin
 		public static void SetPrivateField(object obj, string fieldName, object value)
 		{
 			var prop = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-			prop.SetValue(obj, value);
+            prop.SetValue(obj, value);
 		}
 		
 		public static T GetPrivateField<T>(object obj, string fieldName)
 		{
+            //Plugin.Log("GetPrivateField : " + obj.ToString() + " fieldName: " + fieldName);
 			var prop = obj.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
 			var value = prop.GetValue(obj);
 			return (T) value;

--- a/PracticePlugin/ScoreListItem.cs
+++ b/PracticePlugin/ScoreListItem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PracticePlugin
+{
+    class ScoreListItem
+    {
+        public int baseScore = 0;
+        public int previousScore = 0;
+        public int multiplier = 0;
+        public int multiplierIncreaseProgress = 0;
+        public int multiplierIncreaseMaxProgress = 0;
+        public int combo = 0;
+        public int maxCombo = 0;
+        public bool playerHeadWasInObstacle;
+        public List<AfterCutScoreBuffer> afterCutScoreBuffers = new List<AfterCutScoreBuffer>();
+        
+        public ScoreListItem() { }
+    }
+}

--- a/PracticePlugin/SpeedSettingsCreator.cs
+++ b/PracticePlugin/SpeedSettingsCreator.cs
@@ -4,10 +4,10 @@ using UnityEngine;
 namespace PracticePlugin
 {
 	public class SpeedSettingsCreator : MonoBehaviour
-	{
-		private GameObject _speedSettings;
-		
-		private void OnEnable()
+    {
+        private GameObject _speedSettings;
+
+        private void OnEnable()
 		{
 			if (!Plugin.Enabled) return;
 			_speedSettings = Instantiate(Plugin.SettingsObject, transform);


### PR DESCRIPTION
I can't seem to get scores to rewind correctly, I was hoping you could take a look at it and maybe make some suggestions.
I have the fork on my github, but this pull req is the easiest way to show the changes I've made.

Score data is stored in game within the "ScoreController" class.
Currently on every beat I try to store all data from the "ScoreController" into an object of the class I made called "ScoreListItem", then I store this object in a Dictionary using the beat as the key.
So on every beat I try to take a snapshot of all of the score data, then when I rewind I should be able to reapply this data.
I attempt to do this rewind within the "RewindScore" function in Plugin.cs
If test the plugin in game and apply the rewind, it appears to work at first, but then when the song starts playing again and you hit a note, it seems to add the old score onto the new score. I'm not sure what I'm missing here, but I'm doing something wrong.

I'm currently printing out a bunch of data to the log, and it appears to be storing the score data correctly in the dictionary. Part of the problem is that I'm not sure if this is an issue with the display in game not updating correctly, or the actual score value.

How to use:
    Must be in No Fail mode.
    Press "r" to activate rewind. It rewinds 1 beat at a time.
    Will not work if paused.